### PR TITLE
fix the error: ModuleNotFound by add it in the requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ colorama
 requests
 chardet
 ua_generator
+setuptools


### PR DESCRIPTION
Hi there,

In the requirements.txt file, `setuptools` library was forgotten to be added. This caused an error when try to build the package for usage. Here is the error:

```
Traceback (most recent call last):
  File "/Users/apple/ghauri/setup.py", line 3, in <module>
    from setuptools import setup, find_packages
ModuleNotFoundError: No module named 'setuptools'
```