### PR TITLE
feat: allow float values for delay

### DIFF
--- a/ghauri/scripts/ghauri.py
+++ b/ghauri/scripts/ghauri.py
@@ -193,7 +193,7 @@ def main():
     request.add_argument(
         "--delay",
         dest="delay",
-        type=int,
+        type=float,
         help="Delay in seconds between each HTTP request",
         default=0,
         metavar="",


### PR DESCRIPTION
Currently `--delay` is the delay between http requests in seconds as an integer value, meaning you can not set delay between requests to be less than 1 second. This pr changes the flag to accept float values.